### PR TITLE
Add light_on_off_toggle option for ON/OFF buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Values outside these ranges are discouraged.
 | `light_step_pct`        | ✘         | `10`           | Step size (pct)          |
 | `light_transition_on`   | ✘         | `0`            | Fade-in time (seconds)   |
 | `light_transition_off`  | ✘         | `0`            | Fade-out time (seconds)  |
+| `light_on_off_toggle`   | ✘         | `false`        | Use toggle for ON/OFF    |
 | `media_player_vol_step` | ✘         | `10`           | Volume step (pct)        |
 
 ### Light Transitions
@@ -164,6 +165,18 @@ lights are turned ON or OFF via tap actions.
 - When set to `0`, the transition parameter is **not sent** to Home Assistant
 - Transitions apply to **tap ON / OFF only**
 - Step and ramp actions are always instant for responsiveness
+
+### Light Toggle Mode
+
+`light_on_off_toggle` changes the ON and OFF buttons to **toggle** behavior
+instead of their default discrete on/off actions.
+
+- When `true`, both ON and OFF buttons check the current light state and flip it
+- When `false` (default), ON always turns on, OFF always turns off
+- Works with all Pico types (P2B, 2B, 3BRL)
+- For P2B / 2B: tap toggles, hold still ramps (direction unchanged)
+- Useful when a single remote controls one light group and you want either
+  button to work regardless of current state
 
 ---
 
@@ -225,13 +238,13 @@ target:
 
 ### 💡 Lights
 
-| Button | Action                   |
-| ------ | ------------------------ |
-| ON     | turn_on → `light_on_pct` |
-| OFF    | turn_off                 |
-| RAISE  | step / ramp up           |
-| LOWER  | step / ramp down         |
-| STOP   | no-op                    |
+| Button | Action                                                      |
+| ------ | ----------------------------------------------------------- |
+| ON     | turn_on → `light_on_pct` (or toggle if `light_on_off_toggle`) |
+| OFF    | turn_off (or toggle if `light_on_off_toggle`)                 |
+| RAISE  | step / ramp up                                              |
+| LOWER  | step / ramp down                                            |
+| STOP   | no-op                                                       |
 
 ### 🌀 Fans
 
@@ -309,6 +322,15 @@ pico_link:
         - light.bedroom_main
         - light.bedroom_lamps
       middle_button: default
+
+    # 3BRL — lights, toggle mode (ON and OFF both toggle)
+    - name: Living Room Remote
+      type: 3BRL
+      lights:
+        - light.living_room_lamp
+      light_on_off_toggle: true
+      light_transition_on: 1
+      light_transition_off: 1
 
     # 3BRL — fan, custom STOP
     - name: Living Room Fan

--- a/custom_components/pico_link/actions/light_actions.py
+++ b/custom_components/pico_link/actions/light_actions.py
@@ -122,22 +122,25 @@ class LightActions:
         ON behavior:
 
         - P2B / 2B:
-            * Tap  -> turn_on(light_on_pct)
+            * Tap  -> turn_on(light_on_pct) [or toggle if light_on_off_toggle]
             * Hold -> ramp brightness up until release
         - Other profiles:
-            * ON is simple turn_on (tap-only)
+            * ON is simple turn_on (tap-only) [or toggle if light_on_off_toggle]
         """
         # Any press = new intent; stop any ongoing motion immediately
         self._abort_motion()
 
         if self._supports_onoff_hold():
             self._start_onoff_hold(button="on", direction=1)
+        elif self.ctrl.conf.light_on_off_toggle:
+            asyncio.create_task(self._toggle())
         else:
             asyncio.create_task(self._turn_on())
 
     def release_on(self):
         if self._supports_onoff_hold():
-            self._finalize_onoff_hold(button="on", tap_action=self._turn_on)
+            tap = self._toggle if self.ctrl.conf.light_on_off_toggle else self._turn_on
+            self._finalize_onoff_hold(button="on", tap_action=tap)
         # For tap-only profiles, ON release is a no-op.
 
     # --- OFF -------------------------------------------------------
@@ -146,22 +149,25 @@ class LightActions:
         OFF behavior:
 
         - P2B / 2B:
-            * Tap  -> turn_off
+            * Tap  -> turn_off [or toggle if light_on_off_toggle]
             * Hold -> ramp brightness down until release
         - Other profiles:
-            * OFF is simple turn_off (tap-only)
+            * OFF is simple turn_off (tap-only) [or toggle if light_on_off_toggle]
         """
         # Any press = new intent; stop any ongoing motion immediately
         self._abort_motion()
 
         if self._supports_onoff_hold():
             self._start_onoff_hold(button="off", direction=-1)
+        elif self.ctrl.conf.light_on_off_toggle:
+            asyncio.create_task(self._toggle())
         else:
             asyncio.create_task(self._turn_off())
 
     def release_off(self):
         if self._supports_onoff_hold():
-            self._finalize_onoff_hold(button="off", tap_action=self._turn_off)
+            tap = self._toggle if self.ctrl.conf.light_on_off_toggle else self._turn_off
+            self._finalize_onoff_hold(button="off", tap_action=tap)
         # For tap-only profiles, OFF release is a no-op.
 
     # --- STOP ------------------------------------------------------
@@ -345,6 +351,16 @@ class LightActions:
             params,
             domain="light",
         )
+
+    async def _toggle(self):
+        """Toggle light on/off based on current state."""
+        state = self.ctrl.utils.get_entity_state()
+        is_on = state and state.state == "on"
+
+        if is_on:
+            await self._turn_off()
+        else:
+            await self._turn_on()
 
     async def _step_brightness(self, direction: int):
         """

--- a/custom_components/pico_link/config.py
+++ b/custom_components/pico_link/config.py
@@ -47,6 +47,7 @@ class PicoConfig:
     light_step_pct: int = 10       # 1–25
     light_transition_on: int = 0   # 0-300
     light_transition_off: int = 0  # 0-300
+    light_on_off_toggle: bool = False  # Use toggle instead of discrete on/off
 
     # Media player config
     media_player_vol_step: int = 10  # 1–20 recommended
@@ -302,6 +303,11 @@ def parse_pico_config(
         max_val=300,
     )
 
+    light_on_off_toggle = _normalize_bool(
+        raw_val=merged.get("light_on_off_toggle", False),
+        default=False,
+    )
+
     media_player_vol_step = _normalize_int(
         raw_val=merged.get("media_player_vol_step", 10),
         default=10,
@@ -351,6 +357,7 @@ def parse_pico_config(
         light_step_pct=light_step_pct,
         light_transition_on=light_transition_on,
         light_transition_off=light_transition_off,
+        light_on_off_toggle=light_on_off_toggle,
 
         media_player_vol_step=media_player_vol_step,
 


### PR DESCRIPTION
## Summary

Adds a new `light_on_off_toggle` configuration option that changes ON and OFF button behavior from discrete turn_on/turn_off to toggle.

- New boolean config option `light_on_off_toggle` (default: `false`)
- When enabled, both ON and OFF buttons check current light state and flip it
- Works with all Pico types: **3BRL** (tap toggles), **P2B** and **2B** (tap toggles, hold still ramps in the original direction)
- Follows existing config patterns (`_normalize_bool`, defaults merging, per-device override)

## Use case

When a Pico controls a single light or light group, it's convenient to have either button toggle regardless of current state — especially in the dark where you don't want to think about which button you're reaching for. This is a common request in the HA community for Pico remotes.

## Changes

- **`config.py`** — new `light_on_off_toggle` field on `PicoConfig`, parsed via `_normalize_bool`
- **`actions/light_actions.py`** — `press_on`/`press_off` and `release_on`/`release_off` check the flag; new `_toggle()` method reads entity state
- **`README.md`** — config table, dedicated docs section, behavior table updated, sample config example

## Example

```yaml
pico_link:
  devices:
    - name: Living Room Remote
      type: 3BRL
      lights:
        - light.living_room_lamp
      light_on_off_toggle: true
```

## Backward compatible

Defaults to `false` — no behavior change for existing configs.