### PR TITLE
[Proposal] Full UI configuration via config flow (breaking, drops YAML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,30 +24,31 @@ lutron_caseta_button_event
 ```
 
 and routes Pico button events to lights, fans, covers, media players, switches,
-scenes, scripts, and other Home Assistant services.
+scenes, scripts, and other Home Assistant actions.
 
 Features include:
 
+- Fully configured through the Home Assistant UI — no YAML editing
 - Tap-versus-hold detection where supported
 - Brightness, volume, and cover-position stepping
 - Continuous light, cover, and media-player ramping
 - Tap-only fan speed control
 - Domain-specific STOP-button behavior
-- Ordered custom action execution
+- Ordered custom action execution, built with Home Assistant's native action
+  picker
 - Entity placeholder expansion
 - Optimistic light and cover targets for responsive repeated taps
 - Validation of Pico types, entities, domains, actions, and button mappings
-- Protection against duplicate Pico device configuration
+- Protection against configuring the same physical Pico twice
 - Verification that the configured Pico type matches the reported hardware type
 
 ---
 
 ## Requirements
 
-- Home Assistant 2023.1.0 or newer
+- Home Assistant 2024.10.0 or newer
 - The Home Assistant **Lutron Caséta** integration configured and working
 - Pico button events available as `lutron_caseta_button_event`
-- YAML configuration in `configuration.yaml`
 
 Pico Link depends on the Home Assistant `lutron_caseta` integration and is
 loaded after it.
@@ -57,13 +58,13 @@ loaded after it.
 ## Supported Pico Types
 
 | Type   | Layout                          | Buttons                                   | Supported behavior                                     |
-| ------ | ------------------------------- | ----------------------------------------- | ------------------------------------------------------ |
+| ------ | -------------------------------- | ------------------------------------------ | -------------------------------------------------------- |
 | `P2B`  | Paddle Pico                     | `on`, `off`                               | Domain-specific ON/OFF tap and hold behavior           |
 | `2B`   | Two-button Pico                 | `on`, `off`                               | Domain-specific ON/OFF tap and hold behavior           |
 | `3BRL` | On / Raise / Stop / Lower / Off | `on`, `raise`, `stop`, `lower`, `off`     | Full domain control with dedicated raise/lower buttons |
 | `4B`   | Four-button scene Pico          | `button_1`, `button_2`, `button_3`, `off` | Ordered custom actions only                            |
 
-The configured `type` is authoritative. Pico Link verifies the hardware type
+The configured type is authoritative. Pico Link verifies the hardware type
 reported by Lutron events. Events are ignored when the reported hardware type
 does not match the configured type.
 
@@ -104,190 +105,102 @@ config/
 └── custom_components/
     └── pico_link/
         ├── __init__.py
+        ├── config_flow.py
         ├── manifest.json
         ├── config.py
         ├── controller.py
         ├── utilities.py
         ├── actions/
-        └── profiles/
+        ├── profiles/
+        └── translations/
 ```
 
 Restart Home Assistant after installation or updates.
 
 ---
 
-## Basic Configuration
+## Adding a Pico
 
-Add Pico Link to `configuration.yaml`:
+Each physical Pico remote is added and configured independently, entirely
+from the Home Assistant UI.
 
-```yaml
-pico_link:
-  defaults:
-    # Optional shared settings
+1. Go to **Settings → Devices & Services**.
+2. Click **Add Integration** and choose **Pico Link**.
+3. Pick the Pico from the dropdown. Only Lutron Pico remotes that aren't
+   already configured are listed — the Smart Bridge, fan speed controllers,
+   and already-configured Picos don't show up. Its type is read directly
+   from the model Lutron reports, so there's nothing to select or get wrong.
+4. **For `P2B`, `2B`, and `3BRL` Picos:** fill in the entities for the one
+   domain this Pico controls (cover, fan, light, media player, or switch),
+   and leave the other fields empty. Click **Submit** and you're done — it
+   starts working immediately with sensible default timing and behavior.
+5. **For `4B` Picos:** build an action sequence for each button
+   (`button_1`, `button_2`, `button_3`, `off`) using Home Assistant's action
+   picker. At least one button must be configured.
 
-  devices:
-    # One entry per physical Pico
-```
+The same physical Pico can only be configured once — adding it a second time
+is blocked automatically, and it drops out of the device list once added.
 
-Each non-4B device must define:
+### Editing a Pico
 
-- `type`
-- `name` or `device_id`
-- Exactly one controlled domain
+Open the Pico's entry under **Settings → Devices & Services** and click
+**Configure**. Non-4B Picos get the same entity picker used during setup
+(you can even switch which domain it controls here), followed by the timing
+and domain-specific [options](#options), and for `3BRL` Picos, a STOP-button
+action builder — none of which the initial add flow asks about, since the
+defaults just work. 4B Picos get the same button-action editor used during
+setup. Changes take effect immediately; Pico Link automatically reloads the
+affected Pico.
 
-Supported domain keys are:
+The Pico's underlying device and its type are fixed once created (since the
+type is read from the hardware, there's nothing to change there anyway). To
+link a different physical Pico, remove the integration entry and add it
+again.
 
-```yaml
-covers:
-fans:
-lights:
-media_players:
-switches:
-```
+### Removing a Pico
 
-A 4B Pico uses `buttons:` instead of an entity domain.
-
----
-
-## Device Identification
-
-A Pico can be identified by Home Assistant device name:
-
-```yaml
-- name: Kitchen Pico
-  type: 3BRL
-  lights:
-    - light.kitchen
-```
-
-Or by Home Assistant device ID:
-
-```yaml
-- device_id: 0123456789abcdef0123456789abcdef
-  type: 3BRL
-  lights:
-    - light.kitchen
-```
-
-Name matching checks the user-assigned device name first, then the
-integration-provided device name.
-
-When more than one device has the same name, configure the Pico using
-`device_id`.
-
-The same physical Pico `device_id` may appear only once under `devices:`. Later
-duplicate entries are rejected.
+Open the Pico's entry under **Settings → Devices & Services**, click the
+three-dot menu, and choose **Delete**.
 
 ---
 
 ## Entity Configuration
 
-A domain may be configured as one entity ID:
+A domain may be assigned one entity or several. When multiple entities are
+selected:
 
-```yaml
-lights: light.kitchen
-```
+- Commands are sent to all of them.
+- State-dependent calculations use the first selected entity as the
+  reference.
 
-Or as a list:
-
-```yaml
-lights:
-  - light.kitchen_ceiling
-  - light.kitchen_pendants
-```
-
-Pico Link validates that:
-
-- Every entity ID is a string.
-- Every entity ID has a valid Home Assistant format.
-- Every entity belongs to the expected domain.
-- Duplicate entity IDs are removed while preserving order.
-- Non-4B devices configure exactly one domain.
-
-Examples of invalid assignments:
-
-```yaml
-lights:
-  - fan.bedroom
-```
-
-```yaml
-fans:
-  - null
-```
-
-```yaml
-covers:
-  - living_room_shade
-```
-
-### Multiple entities
-
-When multiple entities are configured:
-
-- Service commands are sent to all configured entities.
-- State-dependent calculations use the first configured entity as the reference.
-
-For example, when several lights are assigned, brightness steps are calculated
-from the first light and the resulting brightness is sent to all assigned
-lights.
+For example, when several lights are assigned, brightness steps are
+calculated from the first light and the resulting brightness is sent to all
+assigned lights.
 
 ---
 
-## Timing Configuration
+## Options
 
-Pico Link uses timing thresholds for tap-versus-hold detection and repeated ramp
-operations.
+Every timing and domain option is configured on the **Options** step of setup
+(or editing), pre-filled with these defaults:
 
-| Parameter      | Default | Accepted range | Purpose                              |
-| -------------- | ------: | -------------: | ------------------------------------ |
-| `hold_time_ms` |   `400` |     `100–2000` | Delay before a press becomes a hold  |
-| `step_time_ms` |   `650` |     `100–2000` | Delay between repeated ramp commands |
+| Field                    | Applies to          |        Default | Range or values                       |
+| ------------------------ | -------------------- | --------------: | -------------------------------------- |
+| `hold_time_ms`           | Light, cover, media  |          `400` | `100–2000` ms                         |
+| `step_time_ms`           | Light, cover, media  |          `650` | `100–2000` ms                         |
+| `cover_open_pos`         | Cover                |          `100` | `1–100` percent                       |
+| `cover_step_pct`         | Cover                |           `10` | `1–25` percent                        |
+| `cover_inverted`         | Cover                |        `false` | Boolean                               |
+| `fan_on_pct`             | Fan                  |          `100` | `1–100` percent                       |
+| `light_on_pct`           | Light                |          `100` | `1–100` percent                       |
+| `light_low_pct`          | Light                |            `5` | `1–99` percent                        |
+| `light_step_pct`         | Light                |           `10` | `1–25` percent                        |
+| `light_transition_on`    | Light                |            `0` | `0–300` seconds                       |
+| `light_transition_off`   | Light                |            `0` | `0–300` seconds                       |
+| `media_player_vol_step`  | Media player         |           `10` | `1–20` percent                        |
 
-Recommended values:
-
-```yaml
-hold_time_ms: 400
-step_time_ms: 650
-```
-
-Poor timing values can cause missed taps, overly sensitive holds, or slow ramp
-behavior.
-
-These settings affect lights, covers, and media players. Fans are always
-tap-only.
-
----
-
-## Configuration Options
-
-| Key                     | Applies to          |        Default | Accepted range or values              |
-| ----------------------- | ------------------- | -------------: | ------------------------------------- |
-| `type`                  | All                 |       Required | `P2B`, `2B`, `3BRL`, `4B`             |
-| `name`                  | All                 |              — | Home Assistant device name            |
-| `device_id`             | All                 |              — | Home Assistant device ID              |
-| `covers`                | Non-4B              |              — | One or more `cover.*` entities        |
-| `fans`                  | Non-4B              |              — | One or more `fan.*` entities          |
-| `lights`                | Non-4B              |              — | One or more `light.*` entities        |
-| `media_players`         | Non-4B              |              — | One or more `media_player.*` entities |
-| `switches`              | Non-4B              |              — | One or more `switch.*` entities       |
-| `buttons`               | 4B                  |       Required | Button-to-action mapping              |
-| `middle_button`         | 3BRL                | Domain default | Custom STOP actions                   |
-| `hold_time_ms`          | Light, cover, media |          `400` | `100–2000` ms                         |
-| `step_time_ms`          | Light, cover, media |          `650` | `100–2000` ms                         |
-| `cover_open_pos`        | Cover               |          `100` | `1–100` percent                       |
-| `cover_step_pct`        | Cover               |           `10` | `1–25` percent                        |
-| `cover_inverted`        | Cover               |        `false` | Boolean                               |
-| `fan_on_pct`            | Fan                 |          `100` | `1–100` percent                       |
-| `light_on_pct`          | Light               |          `100` | `1–100` percent                       |
-| `light_low_pct`         | Light               |            `5` | `1–99` percent                        |
-| `light_step_pct`        | Light               |           `10` | `1–25` percent                        |
-| `light_transition_on`   | Light               |            `0` | `0–300` seconds                       |
-| `light_transition_off`  | Light               |            `0` | `0–300` seconds                       |
-| `media_player_vol_step` | Media player        |           `10` | `1–20` percent                        |
-
-Numeric values outside their accepted ranges are clamped. Invalid numeric values
-use their defaults.
+Only the fields relevant to the Pico's assigned domain are shown. Numeric
+selectors are clamped to their listed range.
 
 ---
 
@@ -307,12 +220,12 @@ use their defaults.
 #### 3BRL
 
 | Button | Tap                                         | Hold          |
-| ------ | ------------------------------------------- | ------------- |
+| ------ | -------------------------------------------- | ------------- |
 | ON     | Turn on at `light_on_pct`                   | —             |
 | OFF    | Turn off                                    | —             |
 | RAISE  | Increase by `light_step_pct`                | Ramp upward   |
 | LOWER  | Decrease by `light_step_pct`                | Ramp downward |
-| STOP   | Custom `middle_button`, otherwise no action | —             |
+| STOP   | Custom STOP actions, otherwise no action    | —             |
 
 Brightness does not ramp below `light_low_pct`.
 
@@ -322,16 +235,8 @@ short period instead of waiting for Home Assistant state to update.
 ### Light transitions
 
 `light_transition_on` and `light_transition_off` apply only to ON and OFF tap
-actions.
-
-```yaml
-light_transition_on: 1
-light_transition_off: 3
-```
-
-When a transition is `0`, the transition field is omitted from the service call.
-
-Brightness steps and ramps do not use transitions.
+actions. When a transition is `0`, the transition field is omitted from the
+action call. Brightness steps and ramps do not use transitions.
 
 ---
 
@@ -340,14 +245,14 @@ Brightness steps and ramps do not use transitions.
 Fan controls are always tap-only. Holding a fan button does not initiate a ramp.
 
 | Button | Action                                              |
-| ------ | --------------------------------------------------- |
+| ------ | ---------------------------------------------------- |
 | ON     | Set speed to `fan_on_pct`                           |
 | OFF    | Turn off                                            |
 | RAISE  | Move up one available fan speed                     |
 | LOWER  | Move down one available fan speed                   |
-| STOP   | Custom `middle_button`, otherwise reverse direction |
+| STOP   | Custom STOP actions, otherwise reverse direction    |
 
-Fan speed steps are calculated from the entity’s `percentage_step` attribute.
+Fan speed steps are calculated from the entity's `percentage_step` attribute.
 
 If the fan is off, RAISE moves it to the first nonzero speed.
 
@@ -364,24 +269,25 @@ If the fan does not expose a usable `percentage_step`, Pico Link falls back to:
 #### P2B and 2B
 
 | Gesture                | Action                                 |
-| ---------------------- | -------------------------------------- |
+| ------------------------ | ----------------------------------------- |
 | ON tap                 | Open to `cover_open_pos`               |
 | ON hold                | Move continuously in the ON direction  |
 | OFF tap                | Close fully                            |
 | OFF hold               | Move continuously in the OFF direction |
 | ON or OFF while moving | Stop movement                          |
 
-When `cover_inverted: true`, ON and OFF tap and hold directions are reversed.
+When `cover_inverted` is enabled, ON and OFF tap and hold directions are
+reversed.
 
 #### 3BRL
 
 | Button | Tap                                    | Hold               |
-| ------ | -------------------------------------- | ------------------ |
+| ------ | ---------------------------------------- | -------------------- |
 | ON     | Open to `cover_open_pos`               | —                  |
 | OFF    | Close fully                            | —                  |
 | RAISE  | Increase position by `cover_step_pct`  | Open continuously  |
 | LOWER  | Decrease position by `cover_step_pct`  | Close continuously |
-| STOP   | Custom `middle_button`, otherwise stop | —                  |
+| STOP   | Custom STOP actions, otherwise stop    | —                  |
 
 Rapid repeated cover taps use the most recently requested target position for a
 short period instead of waiting for `current_position` to update.
@@ -405,19 +311,14 @@ When changing direction after continuous movement, Pico Link waits for
 #### 3BRL
 
 | Button | Tap                                           | Hold                      |
-| ------ | --------------------------------------------- | ------------------------- |
+| ------ | ------------------------------------------------ | --------------------------- |
 | ON     | Play or pause                                 | —                         |
 | OFF    | Next track                                    | —                         |
 | RAISE  | Raise volume one step                         | Raise volume continuously |
 | LOWER  | Lower volume one step                         | Lower volume continuously |
-| STOP   | Custom `middle_button`, otherwise toggle mute | —                         |
+| STOP   | Custom STOP actions, otherwise toggle mute    | —                         |
 
-The volume step is configured as a percentage:
-
-```yaml
-media_player_vol_step: 5
-```
-
+The volume step is configured as a percentage via `media_player_vol_step`.
 Volume commands are clamped between `0.0` and `1.0`.
 
 ---
@@ -425,10 +326,10 @@ Volume commands are clamped between `0.0` and `1.0`.
 ### Switches
 
 | Button | Action                                      |
-| ------ | ------------------------------------------- |
+| ------ | -------------------------------------------- |
 | ON     | Turn on                                     |
 | OFF    | Turn off                                    |
-| STOP   | Custom `middle_button`, otherwise no action |
+| STOP   | Custom STOP actions, otherwise no action    |
 | RAISE  | No action                                   |
 | LOWER  | No action                                   |
 
@@ -438,10 +339,10 @@ Switches do not support hold behavior.
 
 ### 4B Scene Controllers
 
-A 4B Pico does not control a domain directly. Each button executes a configured
-list of Home Assistant actions.
+A 4B Pico does not control a domain directly. Each button executes an action
+sequence built with Home Assistant's action picker during setup or editing.
 
-Supported keys are:
+Supported buttons:
 
 ```text
 button_1
@@ -450,302 +351,81 @@ button_3
 off
 ```
 
-Each configured button must contain at least one action.
-
-Actions execute sequentially in the order listed. Each action completes before
-the next action begins.
-
-Example:
-
-```yaml
-- name: Scene Pico
-  type: 4B
-  buttons:
-    button_1:
-      - action: scene.turn_on
-        target:
-          entity_id: scene.movie
-
-    button_2:
-      - action: script.turn_on
-        target:
-          entity_id: script.good_night
-
-    button_3:
-      - action: light.turn_off
-        target:
-          area_id: main_floor
-
-    off:
-      - action: homeassistant.turn_off
-        target:
-          area_id: main_floor
-```
+At least one button must have actions configured. Actions execute
+sequentially in the order they were added; each action completes before the
+next one begins.
 
 ---
 
-## STOP and `middle_button`
+## STOP Actions and Domain Defaults
 
-`middle_button` is valid only for `3BRL` Picos.
+Custom STOP actions are valid only for `3BRL` Picos, configured on the
+**STOP button** step.
 
 Resolution order:
 
-1. Explicit actions configured on the device
-2. Shared default actions when the device specifies `middle_button: default`
-3. Domain-specific STOP behavior when `middle_button` is omitted or empty
+1. Custom STOP actions configured on the Pico
+2. Domain-specific STOP behavior when no custom actions are configured
 
 ### Domain defaults
 
 | Domain       | Default STOP behavior |
-| ------------ | --------------------- |
+| ------------- | ------------------------ |
 | Cover        | Stop movement         |
-| Fan          | Reverse direction     |
-| Light        | No action             |
-| Media player | Toggle mute           |
-| Switch       | No action             |
+| Fan          | Reverse direction      |
+| Light        | No action              |
+| Media player | Toggle mute            |
+| Switch       | No action              |
 
-### Use domain default
-
-Omit `middle_button`:
-
-```yaml
-- name: Living Room Fan
-  type: 3BRL
-  fans:
-    - fan.living_room
-```
-
-Or explicitly provide an empty list:
-
-```yaml
-middle_button: []
-```
-
-### Use the shared default
-
-Define a shared default:
-
-```yaml
-pico_link:
-  defaults:
-    middle_button:
-      - action: light.turn_on
-        target:
-          entity_id: light.accent
-```
-
-Opt in from a 3BRL device:
-
-```yaml
-middle_button: default
-```
-
-### Device-specific actions
-
-```yaml
-middle_button:
-  - action: scene.turn_on
-    target:
-      entity_id: scene.relax
-
-  - action: media_player.media_play
-    target:
-      entity_id: media_player.living_room
-```
-
-Custom action lists execute sequentially.
+To use the domain default, leave the STOP button step empty.
 
 ---
 
 ## Entity Placeholders
 
-Within a 3BRL `middle_button` action, these values can be used as
-`target.entity_id` placeholders:
+Within a 3BRL STOP action or a 4B button action, these values can be used as
+a `target.entity_id`:
 
 | Placeholder     | Expands to                           |
-| --------------- | ------------------------------------ |
+| ----------------- | --------------------------------------- |
 | `covers`        | All configured cover entities        |
 | `fans`          | All configured fan entities          |
 | `lights`        | All configured light entities        |
 | `media_players` | All configured media-player entities |
 | `switches`      | All configured switch entities       |
 
-Single placeholder:
+Because these placeholders are not real entity IDs, Home Assistant's visual
+entity picker inside the action editor won't offer them. Use the action
+editor's **Edit in YAML** toggle for that action to type a placeholder
+directly, for example:
 
 ```yaml
-middle_button:
-  - action: light.turn_on
-    target:
-      entity_id: lights
+action: light.turn_on
+target:
+  entity_id: lights
 ```
 
-Placeholder mixed with explicit entities:
-
-```yaml
-middle_button:
-  - action: light.turn_on
-    target:
-      entity_id:
-        - lights
-        - light.accent_lamp
-```
-
-Other target fields are preserved during placeholder expansion:
-
-```yaml
-middle_button:
-  - action: light.turn_on
-    target:
-      entity_id: lights
-      area_id: living_room
-```
-
----
-
-## Action Format
-
-Custom actions use Home Assistant’s `domain.service` format:
-
-```yaml
-- action: light.turn_on
-  target:
-    entity_id: light.kitchen
-  data:
-    brightness_pct: 80
-```
-
-Pico Link validates that:
-
-- The action is a mapping.
-- `action` is a string in `domain.service` form.
-- `data`, when provided, is a mapping.
-- `target`, when provided, is a mapping.
-- 4B button values are nonempty action lists.
-
----
-
-## Complete Example
-
-```yaml
-pico_link:
-  defaults:
-    hold_time_ms: 400
-    step_time_ms: 650
-
-    middle_button:
-      - action: light.turn_on
-        target:
-          entity_id: lights
-        data:
-          brightness_pct: 80
-
-  devices:
-    # Paddle Pico controlling a light
-    - name: Kitchen Paddle
-      type: P2B
-      lights:
-        - light.kitchen_main
-      light_on_pct: 100
-      light_transition_on: 1
-      light_transition_off: 3
-
-    # Two-button Pico controlling a switch
-    - name: Closet Pico
-      type: 2B
-      switches:
-        - switch.closet_light
-
-    # 3BRL controlling multiple lights
-    - name: Bedroom Remote
-      type: 3BRL
-      lights:
-        - light.bedroom_main
-        - light.bedroom_lamps
-      light_on_pct: 80
-      light_low_pct: 5
-      light_step_pct: 10
-      middle_button: default
-
-    # Tap-only fan control
-    - name: Living Room Fan
-      type: 3BRL
-      fans:
-        - fan.living_room
-      fan_on_pct: 40
-
-    # Cover control
-    - name: Shade Remote
-      type: 3BRL
-      covers:
-        - cover.living_room_shade
-      cover_open_pos: 100
-      cover_step_pct: 10
-      cover_inverted: false
-
-    # Media-player control
-    - name: Office Media
-      type: 3BRL
-      media_players:
-        - media_player.office_sonos
-      media_player_vol_step: 5
-
-    # Four-button scene control
-    - name: Scene Pico
-      type: 4B
-      buttons:
-        button_1:
-          - action: scene.turn_on
-            target:
-              entity_id: scene.movie
-
-        button_2:
-          - action: script.turn_on
-            target:
-              entity_id: script.good_night
-
-        button_3:
-          - action: light.turn_off
-            target:
-              area_id: main_floor
-
-        off:
-          - action: homeassistant.turn_off
-            target:
-              area_id: main_floor
-```
+A placeholder can also be mixed with explicit entities in the same list, and
+other target fields (like `area_id`) are preserved during expansion.
 
 ---
 
 ## Validation and Error Handling
 
-Pico Link validates configuration during Home Assistant startup.
+Pico Link validates each Pico's configuration as it is entered, before the
+step can be submitted:
 
-It checks for:
+- Exactly one domain's entities must be filled in (non-4B), or at least one
+  4B button must have actions, before continuing.
+- Entities are restricted to the correct domain by the entity picker itself.
+- Numeric fields are clamped to their allowed range by the field itself.
+- The same physical Pico cannot be configured more than once, and the type is
+  read from the hardware, so it can never be entered incorrectly.
 
-- Supported Pico types
-- Exactly one domain for non-4B devices
-- No entity domain on 4B devices
-- Correct entity-ID formats
-- Correct entity domains
-- Valid Boolean values
-- Valid action structures
-- Valid 4B button names
-- Nonempty 4B action lists
-- `middle_button` only on 3BRL devices
-- `buttons` only on 4B devices
-- Duplicate Pico `device_id` entries
-
-A malformed device entry is logged and skipped. Other valid Pico entries
-continue loading.
-
-When no valid entries remain, Home Assistant logs:
-
-```text
-pico_link is configured, but no valid Pico devices were created
-```
-
-The specific validation errors for rejected entries appear immediately before
-that summary.
+If a Pico's configuration becomes invalid after an update (for example, an
+assigned entity was deleted), Home Assistant marks that Pico's entry as
+**Setup failed** under **Devices & Services**, with the reason in the Pico
+Link log. Other configured Picos are unaffected.
 
 ---
 
@@ -757,37 +437,23 @@ Confirm:
 
 1. The Lutron Caséta integration is loaded.
 2. The Pico emits `lutron_caseta_button_event`.
-3. The configured `device_id` matches the event’s `device_id`.
-4. The configured `type` matches the type reported in the event.
-5. The assigned entity IDs exist and use the correct domain.
+3. The Pico device selected during setup matches the physical remote sending
+   the event.
+4. The configured type matches the type reported in the event.
+5. The assigned entities still exist and use the correct domain.
 
-### No valid Pico devices were created
+### A Pico's entry shows "Setup failed"
 
-Review the Pico Link log entries immediately before the summary warning. Each
-rejected device entry logs its index, configured name or ID, type, and
-validation error.
+Check the Pico Link log entries for that device for the specific validation
+error, then use **Configure** on the entry to fix it (for example,
+reassigning a deleted entity).
 
 ### Configured and reported Pico types do not match
 
-Pico Link treats the YAML `type` as authoritative and ignores mismatched events.
-
-Correct the configured type to match the physical remote:
-
-```yaml
-type: P2B
-```
-
-```yaml
-type: 2B
-```
-
-```yaml
-type: 3BRL
-```
-
-```yaml
-type: 4B
-```
+Since the type is read from the hardware at setup time, this should only
+happen if a Pico was physically swapped at the same Lutron device
+registration without being re-paired. Remove the integration entry and add
+the Pico again to re-detect its type.
 
 ### Rapid cover or light taps
 
@@ -808,10 +474,13 @@ This is intentional. Fan controls are tap-only.
 After installing an updated version:
 
 1. Restart Home Assistant.
-2. Review the Pico Link startup log.
-3. Confirm that the expected number of controllers was initialized.
-4. Test ON, OFF, RAISE, LOWER, STOP, and custom actions for each configured Pico
-   type.
+2. Check **Settings → Devices & Services** for any Pico Link entry showing
+   **Setup failed** or a repair notification.
+3. Test ON, OFF, RAISE, LOWER, STOP, and custom actions for each configured
+   Pico type.
+
+Editing a Pico's options through **Configure** reloads only that Pico and does
+not require a Home Assistant restart.
 
 ---
 

--- a/custom_components/pico_link/__init__.py
+++ b/custom_components/pico_link/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 
 from .config import parse_pico_config
 from .const import DOMAIN
@@ -51,10 +51,16 @@ async def async_setup_entry(
     entry.runtime_data = controller
 
     # Make sure Pico work is unsubscribed and stopped on a clean HA
-    # shutdown, not just on entry unload.
+    # shutdown, not just on entry unload. Must be a @callback so the
+    # event bus invokes it directly on the event loop rather than in
+    # an executor thread, since it calls hass.async_create_task.
+    @callback
+    def _handle_stop(_event: Event) -> None:
+        hass.async_create_task(controller.async_stop())
+
     unsub_stop = hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP,
-        lambda _event: hass.async_create_task(controller.async_stop()),
+        _handle_stop,
     )
     entry.async_on_unload(unsub_stop)
 

--- a/custom_components/pico_link/__init__.py
+++ b/custom_components/pico_link/__init__.py
@@ -1,174 +1,80 @@
 # __init__.py — Integration entry point
 from __future__ import annotations
 
-import asyncio
 import logging
-from typing import Any
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
 
-from .config import PicoConfig, parse_pico_config
+from .config import parse_pico_config
 from .const import DOMAIN
 from .controller import PicoController
 
 _LOGGER = logging.getLogger(__name__)
 
+type PicoLinkConfigEntry = ConfigEntry[PicoController]
 
-async def async_setup(
+
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigType,
+    entry: PicoLinkConfigEntry,
 ) -> bool:
-    """Set up Pico Link from configuration.yaml."""
-    root = config.get(DOMAIN)
+    """Set up one Pico from a config entry."""
+    device_raw = {
+        "device_id": entry.data["device_id"],
+        "type": entry.data["type"],
+        **entry.options,
+    }
 
-    if root is None:
-        _LOGGER.debug(
-            "No %s configuration found in configuration.yaml",
-            DOMAIN,
-        )
-        return True
-
-    if not isinstance(root, dict):
-        _LOGGER.error(
-            "Invalid %s configuration: expected a mapping with optional "
-            "'defaults' and required 'devices', got %s",
-            DOMAIN,
-            type(root).__name__,
-        )
-        return False
-
-    # =============================================================
-    # DEFAULTS
-    # =============================================================
-
-    raw_defaults = root.get("defaults")
-
-    if raw_defaults is None:
-        defaults: dict[str, Any] = {}
-    elif isinstance(raw_defaults, dict):
-        defaults = raw_defaults
-    else:
-        _LOGGER.error(
-            "Invalid '%s.defaults' configuration: expected a mapping, got %s",
-            DOMAIN,
-            type(raw_defaults).__name__,
-        )
-        return False
-
-    # =============================================================
-    # DEVICES
-    # =============================================================
-
-    device_list = root.get("devices")
-
-    if not isinstance(device_list, list):
-        _LOGGER.error(
-            "Invalid '%s.devices' configuration: expected a list, got %s",
-            DOMAIN,
-            type(device_list).__name__,
-        )
-        return False
-
-    controllers: list[PicoController] = []
-
-    # Track the configuration entry where each physical Pico was first
-    # registered. A second entry for the same device would otherwise
-    # create another controller subscribed to the same Pico events.
-    configured_device_entries: dict[str, int] = {}
-
-    for index, device_raw in enumerate(
-        device_list,
-        start=1,
-    ):
-        if not isinstance(device_raw, dict):
-            _LOGGER.error(
-                "Invalid %s device entry %s: expected a mapping, got %s: %r",
-                DOMAIN,
-                index,
-                type(device_raw).__name__,
-                device_raw,
-            )
-            continue
-
-        try:
-            pico_config: PicoConfig = parse_pico_config(
-                hass,
-                defaults,
-                device_raw,
-            )
-        except ValueError as err:
-            device_identifier = (
-                device_raw.get("device_id") or device_raw.get("name") or "<unknown>"
-            )
-            device_type = device_raw.get("type") or "<unknown>"
-
-            _LOGGER.error(
-                "Invalid %s device entry %s (device=%s, type=%s): %s",
-                DOMAIN,
-                index,
-                device_identifier,
-                device_type,
-                err,
-            )
-            continue
-
-        first_entry = configured_device_entries.get(pico_config.device_id)
-
-        if first_entry is not None:
-            _LOGGER.error(
-                "Invalid %s device entry %s: Pico device %s is "
-                "already configured by entry %s",
-                DOMAIN,
-                index,
-                pico_config.device_id,
-                first_entry,
-            )
-            continue
-
-        configured_device_entries[pico_config.device_id] = index
-
-        controller = PicoController(
+    try:
+        pico_config = parse_pico_config(
             hass,
-            pico_config,
+            device_raw,
         )
-
-        await controller.async_start()
-        controllers.append(controller)
-
-    # =============================================================
-    # COMPLETED SETUP
-    # =============================================================
-
-    if not controllers:
-        _LOGGER.warning(
-            "%s is configured, but no valid Pico devices were created",
+    except ValueError as err:
+        _LOGGER.error(
+            "%s: invalid configuration for entry %s: %s",
             DOMAIN,
+            entry.entry_id,
+            err,
         )
-        return True
+        return False
 
-    hass.data.setdefault(
-        DOMAIN,
-        {},
-    )["controllers"] = controllers
+    controller = PicoController(
+        hass,
+        pico_config,
+    )
 
-    # =============================================================
-    # SHUTDOWN
-    # =============================================================
+    await controller.async_start()
 
-    async def _async_stop(_: Any) -> None:
-        await asyncio.gather(*(controller.async_stop() for controller in controllers))
+    entry.runtime_data = controller
 
-    hass.bus.async_listen_once(
+    # Make sure Pico work is unsubscribed and stopped on a clean HA
+    # shutdown, not just on entry unload.
+    unsub_stop = hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP,
-        _async_stop,
+        lambda _event: hass.async_create_task(controller.async_stop()),
     )
+    entry.async_on_unload(unsub_stop)
 
-    _LOGGER.info(
-        "%s initialized with %s controller(s)",
-        DOMAIN,
-        len(controllers),
-    )
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant,
+    entry: PicoLinkConfigEntry,
+) -> bool:
+    """Unload a Pico config entry."""
+    await entry.runtime_data.async_stop()
+    return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant,
+    entry: PicoLinkConfigEntry,
+) -> None:
+    """Reload a Pico when its options are edited."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/pico_link/config.py
+++ b/custom_components/pico_link/config.py
@@ -510,7 +510,6 @@ def _expand_action_placeholders(
 
 def parse_pico_config(
     hass: HomeAssistant,
-    defaults: dict[str, Any],
     device_raw: dict[str, Any],
 ) -> PicoConfig:
     """Normalize and validate one Pico Link device configuration."""
@@ -524,10 +523,7 @@ def parse_pico_config(
 
     device_type = raw_type.strip().upper()
 
-    # middle_button defaults require an explicit
-    # middle_button: default on the device.
-    merged = {key: value for key, value in defaults.items() if key != "middle_button"}
-    merged.update(device_raw)
+    merged = dict(device_raw)
 
     device_id = _resolve_device_id(
         hass,
@@ -697,15 +693,7 @@ def parse_pico_config(
     raw_middle_button = device_raw.get("middle_button")
 
     if device_type == "3BRL":
-        if raw_middle_button == "default":
-            middle_button = _normalize_action_list(
-                defaults.get(
-                    "middle_button",
-                    [],
-                ),
-                context="defaults.middle_button",
-            )
-        elif raw_middle_button is None:
+        if raw_middle_button is None:
             middle_button = []
         else:
             middle_button = _normalize_action_list(

--- a/custom_components/pico_link/config_flow.py
+++ b/custom_components/pico_link/config_flow.py
@@ -1,0 +1,576 @@
+# config_flow.py — UI configuration for Pico Link
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import selector
+
+from .const import DOMAIN, DOMAIN_ENTITY_FIELDS, PICO_TYPE_MAP, SCENE_BUTTONS
+
+# ================================================================
+# SHARED SCHEMA BUILDERS
+#
+# Used by both the initial config flow and the options flow so a
+# Pico's settings look and validate identically whether it is being
+# created or edited.
+# ================================================================
+
+
+def _percent(
+    min_val: int,
+    max_val: int,
+) -> selector.NumberSelector:
+    return selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=min_val,
+            max=max_val,
+            step=1,
+            mode=selector.NumberSelectorMode.BOX,
+            unit_of_measurement="%",
+        )
+    )
+
+
+def _milliseconds() -> selector.NumberSelector:
+    return selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=100,
+            max=2000,
+            step=50,
+            mode=selector.NumberSelectorMode.BOX,
+            unit_of_measurement="ms",
+        )
+    )
+
+
+def _seconds() -> selector.NumberSelector:
+    return selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=0,
+            max=300,
+            step=1,
+            mode=selector.NumberSelectorMode.BOX,
+            unit_of_measurement="s",
+        )
+    )
+
+
+def _entities_schema(
+    current: dict[str, Any] | None = None,
+) -> vol.Schema:
+    """
+    One optional entity picker per controllable domain.
+
+    Fill in exactly one to both pick the domain and its entities in a
+    single step.
+    """
+    current = current or {}
+
+    return vol.Schema(
+        {
+            vol.Optional(
+                field,
+                default=list(current.get(field, [])),
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain=domain,
+                    multiple=True,
+                )
+            )
+            for domain, field in DOMAIN_ENTITY_FIELDS.items()
+        }
+    )
+
+
+def _chosen_domain(
+    user_input: dict[str, Any],
+) -> tuple[str, str] | None:
+    """Return the (domain, field) with entities filled in, or None."""
+    chosen = [
+        (domain, field)
+        for domain, field in DOMAIN_ENTITY_FIELDS.items()
+        if user_input.get(field)
+    ]
+
+    if len(chosen) != 1:
+        return None
+
+    return chosen[0]
+
+
+def _options_schema(
+    domain: str,
+    current: dict[str, Any] | None = None,
+) -> vol.Schema:
+    current = current or {}
+    fields: dict[Any, Any] = {}
+
+    if domain in ("cover", "light", "media_player"):
+        fields[
+            vol.Optional(
+                "hold_time_ms",
+                default=current.get(
+                    "hold_time_ms",
+                    400,
+                ),
+            )
+        ] = _milliseconds()
+
+        fields[
+            vol.Optional(
+                "step_time_ms",
+                default=current.get(
+                    "step_time_ms",
+                    650,
+                ),
+            )
+        ] = _milliseconds()
+
+    if domain == "cover":
+        fields[
+            vol.Optional(
+                "cover_open_pos",
+                default=current.get(
+                    "cover_open_pos",
+                    100,
+                ),
+            )
+        ] = _percent(1, 100)
+
+        fields[
+            vol.Optional(
+                "cover_step_pct",
+                default=current.get(
+                    "cover_step_pct",
+                    10,
+                ),
+            )
+        ] = _percent(1, 25)
+
+        fields[
+            vol.Optional(
+                "cover_inverted",
+                default=current.get(
+                    "cover_inverted",
+                    False,
+                ),
+            )
+        ] = selector.BooleanSelector()
+
+    elif domain == "fan":
+        fields[
+            vol.Optional(
+                "fan_on_pct",
+                default=current.get(
+                    "fan_on_pct",
+                    100,
+                ),
+            )
+        ] = _percent(1, 100)
+
+    elif domain == "light":
+        fields[
+            vol.Optional(
+                "light_on_pct",
+                default=current.get(
+                    "light_on_pct",
+                    100,
+                ),
+            )
+        ] = _percent(1, 100)
+
+        fields[
+            vol.Optional(
+                "light_low_pct",
+                default=current.get(
+                    "light_low_pct",
+                    5,
+                ),
+            )
+        ] = _percent(1, 99)
+
+        fields[
+            vol.Optional(
+                "light_step_pct",
+                default=current.get(
+                    "light_step_pct",
+                    10,
+                ),
+            )
+        ] = _percent(1, 25)
+
+        fields[
+            vol.Optional(
+                "light_transition_on",
+                default=current.get(
+                    "light_transition_on",
+                    0,
+                ),
+            )
+        ] = _seconds()
+
+        fields[
+            vol.Optional(
+                "light_transition_off",
+                default=current.get(
+                    "light_transition_off",
+                    0,
+                ),
+            )
+        ] = _seconds()
+
+    elif domain == "media_player":
+        fields[
+            vol.Optional(
+                "media_player_vol_step",
+                default=current.get(
+                    "media_player_vol_step",
+                    10,
+                ),
+            )
+        ] = _percent(1, 20)
+
+    return vol.Schema(fields)
+
+
+def _middle_button_schema(
+    current: list[dict[str, Any]] | None = None,
+) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Optional(
+                "middle_button",
+                default=list(current or []),
+            ): selector.ActionSelector(),
+        }
+    )
+
+
+def _buttons_schema(
+    current: dict[str, list[dict[str, Any]]] | None = None,
+) -> vol.Schema:
+    current = current or {}
+
+    return vol.Schema(
+        {
+            vol.Optional(
+                name,
+                default=list(current.get(name, [])),
+            ): selector.ActionSelector()
+            for name in SCENE_BUTTONS
+        }
+    )
+
+
+def _eligible_pico_devices(
+    hass: Any,
+) -> dict[str, tuple[str, str]]:
+    """
+    Find Lutron Pico remotes that aren't already configured.
+
+    Returns {device_id: (display_name, pico_type)}. The Pico type is
+    read directly from the model Lutron reports, so it never needs to
+    be entered by hand and can never disagree with the hardware.
+    """
+    device_registry = dr.async_get(hass)
+
+    lutron_entry_ids = {
+        entry.entry_id for entry in hass.config_entries.async_entries("lutron_caseta")
+    }
+
+    configured_device_ids = {
+        entry.data.get("device_id") for entry in hass.config_entries.async_entries(DOMAIN)
+    }
+
+    devices: dict[str, tuple[str, str]] = {}
+
+    for device in device_registry.devices.values():
+        if not device.config_entries & lutron_entry_ids:
+            continue
+
+        if device.id in configured_device_ids:
+            continue
+
+        model = device.model or ""
+        pico_type = next(
+            (code for raw, code in PICO_TYPE_MAP.items() if raw in model),
+            None,
+        )
+
+        if pico_type is None:
+            # Not a Pico (e.g. the Smart Bridge or a Fan Speed Controller).
+            continue
+
+        devices[device.id] = (
+            device.name_by_user or device.name or device.id,
+            pico_type,
+        )
+
+    return devices
+
+
+# ================================================================
+# CONFIG FLOW (add a new Pico)
+# ================================================================
+
+
+class PicoLinkConfigFlow(
+    config_entries.ConfigFlow,
+    domain=DOMAIN,
+):
+    """Handle adding a single Pico as a config entry."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        self._device_id: str | None = None
+        self._type: str | None = None
+        self._domain: str = ""
+        self._title: str = ""
+        self._options: dict[str, Any] = {}
+
+    async def async_step_user(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        devices = _eligible_pico_devices(self.hass)
+
+        if not devices:
+            return self.async_abort(reason="no_devices_found")
+
+        if user_input is not None:
+            device_id = user_input["device_id"]
+
+            await self.async_set_unique_id(device_id)
+            self._abort_if_unique_id_configured()
+
+            self._device_id = device_id
+            self._title, self._type = devices[device_id]
+
+            if self._type == "4B":
+                return await self.async_step_buttons()
+
+            return await self.async_step_entities()
+
+        schema = vol.Schema(
+            {
+                vol.Required("device_id"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            selector.SelectOptionDict(
+                                value=device_id,
+                                label=title,
+                            )
+                            for device_id, (title, _type) in sorted(
+                                devices.items(),
+                                key=lambda item: item[1][0],
+                            )
+                        ],
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=schema,
+        )
+
+    async def async_step_entities(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            chosen = _chosen_domain(user_input)
+
+            if chosen is None:
+                errors["base"] = "single_domain_required"
+            else:
+                domain, field = chosen
+                self._domain = domain
+                self._options = {field: user_input[field]}
+                return self._async_finish()
+
+        return self.async_show_form(
+            step_id="entities",
+            data_schema=_entities_schema(),
+            errors=errors,
+        )
+
+    async def async_step_buttons(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            buttons = {
+                name: actions for name, actions in user_input.items() if actions
+            }
+
+            if not buttons:
+                errors["base"] = "buttons_required"
+            else:
+                self._options["buttons"] = buttons
+                return self._async_finish()
+
+        return self.async_show_form(
+            step_id="buttons",
+            data_schema=_buttons_schema(),
+            errors=errors,
+        )
+
+    def _async_finish(self) -> FlowResult:
+        return self.async_create_entry(
+            title=self._title,
+            data={
+                "device_id": self._device_id,
+                "type": self._type,
+            },
+            options=self._options,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "PicoLinkOptionsFlow":
+        return PicoLinkOptionsFlow(config_entry)
+
+
+# ================================================================
+# OPTIONS FLOW (edit an existing Pico)
+#
+# Editing still exposes the timing/behavior options and the 3BRL STOP
+# button, which the initial add flow skips in favor of sensible
+# defaults.
+# ================================================================
+
+
+class PicoLinkOptionsFlow(config_entries.OptionsFlow):
+    """Handle editing an existing Pico's entities, buttons, and options."""
+
+    def __init__(
+        self,
+        config_entry: config_entries.ConfigEntry,
+    ) -> None:
+        self._entry = config_entry
+        self._type: str = config_entry.data["type"]
+        self._domain: str = ""
+        self._options: dict[str, Any] = dict(config_entry.options)
+
+    async def async_step_init(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        if self._type == "4B":
+            return await self.async_step_buttons()
+
+        return await self.async_step_entities()
+
+    async def async_step_entities(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            chosen = _chosen_domain(user_input)
+
+            if chosen is None:
+                errors["base"] = "single_domain_required"
+            else:
+                domain, field = chosen
+
+                # Drop any other domain's entities if the domain changed.
+                for other_field in DOMAIN_ENTITY_FIELDS.values():
+                    if other_field != field:
+                        self._options.pop(other_field, None)
+
+                self._domain = domain
+                self._options[field] = user_input[field]
+                return await self.async_step_options()
+
+        return self.async_show_form(
+            step_id="entities",
+            data_schema=_entities_schema(current=self._options),
+            errors=errors,
+        )
+
+    async def async_step_options(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        if user_input is not None:
+            self._options.update(user_input)
+
+            if self._type == "3BRL":
+                return await self.async_step_middle_button()
+
+            return self._async_finish()
+
+        return self.async_show_form(
+            step_id="options",
+            data_schema=_options_schema(
+                self._domain,
+                current=self._options,
+            ),
+            description_placeholders={"domain": self._domain},
+        )
+
+    async def async_step_middle_button(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        if user_input is not None:
+            self._options["middle_button"] = user_input.get(
+                "middle_button",
+                [],
+            )
+            return self._async_finish()
+
+        return self.async_show_form(
+            step_id="middle_button",
+            data_schema=_middle_button_schema(
+                current=self._options.get("middle_button"),
+            ),
+        )
+
+    async def async_step_buttons(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            buttons = {
+                name: actions for name, actions in user_input.items() if actions
+            }
+
+            if not buttons:
+                errors["base"] = "buttons_required"
+            else:
+                self._options["buttons"] = buttons
+                return self._async_finish()
+
+        return self.async_show_form(
+            step_id="buttons",
+            data_schema=_buttons_schema(
+                current=self._options.get("buttons"),
+            ),
+            errors=errors,
+        )
+
+    def _async_finish(self) -> FlowResult:
+        return self.async_create_entry(
+            title="",
+            data=self._options,
+        )

--- a/custom_components/pico_link/const.py
+++ b/custom_components/pico_link/const.py
@@ -6,7 +6,7 @@ DOMAIN = "pico_link"
 PICO_EVENT_TYPE = "lutron_caseta_button_event"
 
 # --------------------------------------------------------------------
-# VALID YAML TYPES (explicitly required in device config)
+# VALID PICO TYPES (explicitly required in device config)
 # --------------------------------------------------------------------
 VALID_PICO_TYPES = {
     "P2B",  # Paddle Pico
@@ -52,3 +52,15 @@ DOMAIN_ENTITY_FIELDS = {
     "media_player": "media_players",
     "switch": "switches",
 }
+
+# --------------------------------------------------------------------
+# CONFIG FLOW
+# --------------------------------------------------------------------
+
+# 4B scene-button keys, in the order they should appear in the UI.
+SCENE_BUTTONS = [
+    "button_1",
+    "button_2",
+    "button_3",
+    "off",
+]

--- a/custom_components/pico_link/manifest.json
+++ b/custom_components/pico_link/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "Pico Link",
   "domain": "pico_link",
-  "version": "0.3.11",
+  "version": "0.4.0",
+  "config_flow": true,
   "documentation": "https://github.com/smartqasa/pico-link",
   "issue_tracker": "https://github.com/smartqasa/pico-link/issues",
   "codeowners": ["@smartqasa"],

--- a/custom_components/pico_link/manifest.json
+++ b/custom_components/pico_link/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "Pico Link",
   "domain": "pico_link",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "config_flow": true,
-  "documentation": "https://github.com/smartqasa/pico-link",
-  "issue_tracker": "https://github.com/smartqasa/pico-link/issues",
+  "documentation": "https://github.com/davidcoulson/pico-link",
+  "issue_tracker": "https://github.com/davidcoulson/pico-link/issues",
   "codeowners": ["@smartqasa"],
   "iot_class": "local_push",
   "quality_scale": "internal",

--- a/custom_components/pico_link/manifest.json
+++ b/custom_components/pico_link/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "Pico Link",
   "domain": "pico_link",
-  "version": "0.4.1",
+  "version": "0.3.11",
   "config_flow": true,
-  "documentation": "https://github.com/davidcoulson/pico-link",
-  "issue_tracker": "https://github.com/davidcoulson/pico-link/issues",
+  "documentation": "https://github.com/smartqasa/pico-link",
+  "issue_tracker": "https://github.com/smartqasa/pico-link/issues",
   "codeowners": ["@smartqasa"],
   "iot_class": "local_push",
   "quality_scale": "internal",

--- a/custom_components/pico_link/profiles/pico_4b.py
+++ b/custom_components/pico_link/profiles/pico_4b.py
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 class Pico4ButtonScene:
     """
     Pico 4-button scene controller:
-    - Each button maps to a YAML-defined list of HA service calls.
+    - Each button maps to a configured list of HA action calls.
     - Executes each action in order.
     """
 

--- a/custom_components/pico_link/translations/en.json
+++ b/custom_components/pico_link/translations/en.json
@@ -1,0 +1,96 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Add a Pico",
+        "description": "Select the Pico remote to link. Only Lutron Pico devices that aren't already configured are listed — its type is detected automatically from the hardware, so there's nothing else to pick here.",
+        "data": {
+          "device_id": "Pico device"
+        }
+      },
+      "entities": {
+        "title": "What does this Pico control?",
+        "description": "Fill in the entities for the ONE domain this Pico controls, and leave the rest empty.",
+        "data": {
+          "covers": "Covers",
+          "fans": "Fans",
+          "lights": "Lights",
+          "media_players": "Media players",
+          "switches": "Switches"
+        }
+      },
+      "buttons": {
+        "title": "Scene buttons",
+        "description": "Assign one or more actions to each button. A button left empty does nothing when pressed. At least one button must be configured.",
+        "data": {
+          "button_1": "Button 1",
+          "button_2": "Button 2",
+          "button_3": "Button 3",
+          "off": "Off button"
+        }
+      }
+    },
+    "error": {
+      "single_domain_required": "Fill in exactly one of the fields above — the one domain this Pico controls — and leave the rest empty.",
+      "buttons_required": "Configure at least one button with actions."
+    },
+    "abort": {
+      "already_configured": "This Pico is already configured.",
+      "no_devices_found": "No unconfigured Lutron Pico remotes were found. Make sure the Lutron Caséta integration is set up and that the Pico isn't already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "entities": {
+        "title": "What does this Pico control?",
+        "description": "Fill in the entities for the ONE domain this Pico controls, and leave the rest empty.",
+        "data": {
+          "covers": "Covers",
+          "fans": "Fans",
+          "lights": "Lights",
+          "media_players": "Media players",
+          "switches": "Switches"
+        }
+      },
+      "options": {
+        "title": "Options",
+        "description": "Fine-tune timing and behavior for this Pico.",
+        "data": {
+          "hold_time_ms": "Hold time",
+          "step_time_ms": "Step time",
+          "cover_open_pos": "Open position",
+          "cover_step_pct": "Step size",
+          "cover_inverted": "Invert on/off direction",
+          "fan_on_pct": "On speed",
+          "light_on_pct": "On brightness",
+          "light_low_pct": "Minimum brightness",
+          "light_step_pct": "Step size",
+          "light_transition_on": "On transition",
+          "light_transition_off": "Off transition",
+          "media_player_vol_step": "Volume step"
+        }
+      },
+      "middle_button": {
+        "title": "STOP button",
+        "description": "Optional custom actions for the middle (STOP) button. Leave empty to use the default STOP behavior for this domain.",
+        "data": {
+          "middle_button": "STOP actions"
+        }
+      },
+      "buttons": {
+        "title": "Scene buttons",
+        "description": "Assign one or more actions to each button. A button left empty does nothing when pressed. At least one button must be configured.",
+        "data": {
+          "button_1": "Button 1",
+          "button_2": "Button 2",
+          "button_3": "Button 3",
+          "off": "Off button"
+        }
+      }
+    },
+    "error": {
+      "single_domain_required": "Fill in exactly one of the fields above — the one domain this Pico controls — and leave the rest empty.",
+      "buttons_required": "Configure at least one button with actions."
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Pico Link",
-  "homeassistant": "2023.1.0"
+  "homeassistant": "2024.10.0"
 }


### PR DESCRIPTION
## Heads up: this is a different direction, not a fix

Unlike #12 (which is a drop-in backend improvement), this one is a genuine redesign proposal and I fully expect you may not want it — opening it so you can see exactly what it looks like and decide, rather than just describing it in an issue. No hard feelings if this gets closed; my fork ([davidcoulson/pico-link](https://github.com/davidcoulson/pico-link)) exists for anyone who wants this model, independent of what you do here.

## What this changes

- Every Pico is configured entirely through **Settings → Devices & Services** instead of `configuration.yaml`. Each physical Pico becomes its own config entry (`config_flow.py`, new).
- The Pico type (`P2B`/`2B`/`3BRL`/`4B`) is auto-detected from the Lutron-reported device model (`PJ2-3BRL-GXX-X01 (Pico3ButtonRaiseLower)`, etc.), so there's no type field to fill in and no way for it to disagree with the hardware.
- The device picker only lists Lutron Pico remotes that aren't already configured — the Smart Bridge and fan speed controllers (also under the `lutron_caseta` integration) don't show up, and neither does a Pico you've already added.
- Setup asks only for the entities to control; timing/behavior options and the 3BRL STOP action default sensibly and are edited later via each entry's **Configure** screen if wanted.
- **Breaking**: YAML configuration is removed entirely. Existing YAML-configured Picos need to be re-added through the UI after updating. Minimum Home Assistant version goes to **2024.10.0** (needed for the native action-picker selector used by STOP/button actions).

## Why I think it's worth showing you

- Auto-detecting the type from the hardware model eliminates an entire class of user error (configured type vs. reported type mismatches) that shows up in your README's troubleshooting section today.
- No more editing YAML by hand for entity IDs, which are easy to get wrong and only get validated on the next Home Assistant restart.
- This is what most actively-maintained HA custom integrations look like today — HACS's own quality scale nudges toward config-flow-based setup.

## Why you might not want it

- It's a hard break from your stated support for Home Assistant back to 2023.1.0 and YAML config — that's a real design choice you made, not an oversight.
- It's a big diff to review and take on, sight-unseen from an outside contributor.
- Some users may prefer YAML for scripted/version-controlled deployments.

## Testing

Verified against real Home Assistant (`homeassistant` pip package, not this repo's test suite, which I don't have a way to run here): the config flow's device-discovery/type-detection logic against data shaped like a real house (Smart Bridge and a Fan Speed Controller correctly excluded, Pico models correctly mapped to types), the full flow's schemas construct correctly with real HA selectors, and the rewritten `__init__.py`/`config.py` set up and tear down a config entry correctly.

This exact code is also deployed on my own live Home Assistant instance (2026.9.1) via HACS and comes up cleanly (no setup errors in the log). I'm still in the process of adding my physical Picos through it, so I can't yet vouch for extended real-world button-press behavior beyond what the automated checks above cover.

## Note on commit authorship

I used Claude (Anthropic) to help write this, which is why some commits are co-authored. Happy to answer anything about specific decisions in here.